### PR TITLE
add path to search result rows by default

### DIFF
--- a/Controller/PhpcrSearchController.php
+++ b/Controller/PhpcrSearchController.php
@@ -199,6 +199,7 @@ class PhpcrSearchController implements SearchInterface
 
             $searchResults[$contentId] = array(
                 'url' => $url,
+                'path' => $row->getPath(),
                 'title' => $row->getValue($this->searchFields['title']),
                 'summary' => $this->buildSummary($row),
             );


### PR DESCRIPTION
to allow 
    {% for result in searchResults %}
        {% set content = cmf_find(result.path) %}
in twig and access more properties
